### PR TITLE
ruby バージョン変更、schema.rbにコメント挿入

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1
+FROM ruby:2.6.5
 ENV LANG C.UTF-8
 
 RUN apt-get update -qq && apt-get install -y \

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '2.6.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.6.5p114
 
 BUNDLED WITH
    2.1.4

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,15 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
 ActiveRecord::Schema.define(version: 2020_07_10_034853) do
 
   create_table "quests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
railsコマンドを実行する際に警告文が多発するため、rubyのバージョンを 2.7.1から2.6.5に変更
